### PR TITLE
Set `.DisplayName` in `tfbridge.ProviderInfo`

### DIFF
--- a/provider/cmd/pulumi-resource-dnsimple/schema.json
+++ b/provider/cmd/pulumi-resource-dnsimple/schema.json
@@ -1,5 +1,6 @@
 {
     "name": "dnsimple",
+    "displayName": "DNSimple",
     "description": "A Pulumi package for creating and managing dnsimple cloud resources.",
     "keywords": [
         "pulumi",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -51,6 +51,7 @@ func Provider() tfbridge.ProviderInfo {
 	prov := tfbridge.ProviderInfo{
 		P:                pfbridge.ShimProvider(dnsimple.Provider(version.Version)),
 		Name:             "dnsimple",
+		DisplayName:      "DNSimple",
 		Description:      "A Pulumi package for creating and managing dnsimple cloud resources.",
 		Keywords:         []string{"pulumi", "dnsimple"},
 		License:          "Apache-2.0",


### PR DESCRIPTION
This PR is part of pulumi/registry#4672. The display name used was taken from `github.com/pulumi/registry/tools/resourcedocsgen/pkg/lookup.go`.