### PR TITLE
Upgrade terraform-provider-dnsimple to v2.0.0

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -7,6 +7,7 @@ env:
 makeTemplate: bridged
 team: ecosystem
 pulumiConvert: 1
+registryDocs: true
 plugins:
   - name: terraform
     version: "1.0.16"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks
 
-build_sdks: build_nodejs build_python build_dotnet build_go build_java 
+build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
 
 install_go_sdk:
 
@@ -95,6 +95,10 @@ build_python: upstream
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
+
+# Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
+build_registry_docs:
+	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -12,6 +12,7 @@ The dnsimple provider is available as a package in all Pulumi languages:
 * Go: [`github.com/pulumi/pulumi-dnsimple/sdk/v4/go/dnsimple`](https://github.com/pulumi/pulumi-dnsimple)
 * .NET: [`Pulumi.Dnsimple`](https://www.nuget.org/packages/Pulumi.Dnsimple)
 * Java: [`com.pulumi/dnsimple`](https://central.sonatype.com/artifact/com.pulumi/dnsimple)
+## Overview
 
 The DNSimple provider is used to interact with the resources supported by DNSimple. The provider needs to be configured
 with the proper credentials before it can be used.

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -26,6 +26,7 @@ import (
 
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	tfbridgetokens "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -159,6 +160,7 @@ var skipHelpfulLinksSection = tfbridge.DocsEdit{
 			return headerText == "Helpful Links"
 		})
 	},
+	Phase: info.PostCodeTranslation,
 }
 
 // Removes a video link


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi/pulumi-dnsimple --repo-path . --major`.

---

- Updating major version from 4.4.2 to 5.0.0.
- Upgrading terraform-provider-dnsimple from 1.8.0  to 2.0.0.
	Fixes #780
- Upgrading pulumi-terraform-bridge from v3.93.1 to v3.118.0.
