### PR TITLE
Update examples to use Pulumi-owned test domains

### DIFF
--- a/examples/record/csharp/MyStack.cs
+++ b/examples/record/csharp/MyStack.cs
@@ -8,7 +8,7 @@ class MyStack : Stack
         var record = new ZoneRecord("test", new ZoneRecordArgs()
         {
             Ttl = 3600,
-            ZoneName = "stack72.dev",
+            ZoneName = "dnsimple.test.pulumi.com",
             Name = "test-csharp",
             Type = "A",
             Value = "192.168.0.1",

--- a/examples/record/py/__main__.py
+++ b/examples/record/py/__main__.py
@@ -3,7 +3,7 @@ import pulumi_dnsimple as dnsimple
 
 record = dnsimple.ZoneRecord(
     "record",
-    zone_name="stack72.dev",
+    zone_name="dnsimple.test.pulumi.com",
     name="test-py",
     ttl=3600,
     type="A",

--- a/examples/record/ts/index.ts
+++ b/examples/record/ts/index.ts
@@ -15,9 +15,9 @@
 import * as dnsimple from "@pulumi/dnsimple";
 
 let record = new dnsimple.ZoneRecord("test", {
-  zoneName: "stack72.dev",
+  zoneName: "dnsimple.test.pulumi.com",
   name: "test-ts",
-  value: "api.devflix.watch.herokudns.com",
+  value: "example.pulumi.com",
   type: dnsimple.RecordTypes.CNAME,
 });
 


### PR DESCRIPTION
Replace personal domains (`stack72.dev`, `api.devflix.watch.herokudns.com`) in examples with domains we control:

- Zone: `stack72.dev` → `dnsimple.test.pulumi.com`
- CNAME value (TS example): `api.devflix.watch.herokudns.com` → `example.pulumi.com`

Part of pulumi/home#4682
Part of pulumi/pulumi-dnsimple#843
Part of pulumi/pulumi-dnsimple#861
